### PR TITLE
Fix typo in TransactionTable props

### DIFF
--- a/src/lib/components/users/TransactionTable.svelte
+++ b/src/lib/components/users/TransactionTable.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	export let transacitons: {
+	export let transactions: {
 		id: number;
 		title: string;
 		type: string;
@@ -14,7 +14,7 @@
 <figure class="bg-neutral-800 rounded-xl p-4">
 	<figcaption class="text-xl">{title}</figcaption>
 	<ul class="mt-4 grid gap-x-4 grid-cols-[auto_1fr_1fr]">
-		{#each transacitons as transaction (transaction.id)}
+		{#each transactions as transaction (transaction.id)}
 			<li class="contents">
 				<span
 					class="py-2 px-4 font-price text-2xl text-right"

--- a/src/routes/users/[id]/+page.svelte
+++ b/src/routes/users/[id]/+page.svelte
@@ -127,8 +127,8 @@
 			</form>
 		</Container>
 		<Container class="grid lg:grid-cols-2 my-4	gap-4">
-			<TransactionTable transacitons={data.user.initiatorIn} title="Initiated transactions" />
-			<TransactionTable transacitons={data.user.recipientIn} title="Received transactions" />
+			<TransactionTable transactions={data.user.initiatorIn} title="Initiated transactions" />
+			<TransactionTable transactions={data.user.recipientIn} title="Received transactions" />
 		</Container>
 	</main>
 </div>


### PR DESCRIPTION
## Summary
- rename `transacitons` prop to `transactions` in `TransactionTable`
- update `<TransactionTable>` usages to use the new prop name

## Testing
- `npx vitest run --passWithNoTests`
- `npm run lint`
