### PR TITLE
Add HTTP health check to nixos test

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -51,6 +51,7 @@
             testScript = ''
               machine.wait_for_unit("besserestrichliste.service")
               machine.wait_for_open_port(3000)
+              machine.succeed("curl -f http://localhost:3000/")
             '';
           };
 


### PR DESCRIPTION
## Summary
- wait for the besserestrichliste service to respond over HTTP in the NixOS test

## Testing
- `npm test` *(fails: No test files found)*
- `npm run lint`