### PR TITLE
Add 404 loader test and revert lockfile

### DIFF
--- a/src/routes/+error.svelte
+++ b/src/routes/+error.svelte
@@ -1,0 +1,11 @@
+<script lang="ts">
+	import Container from '$lib/components/Container.svelte';
+	export let error: Error & { message: string };
+	export let status: number;
+</script>
+
+<Container class="py-8 text-center">
+	<h1 class="text-3xl font-bold mb-4">{status}</h1>
+	<p class="mb-4">{error?.message}</p>
+	<a href="/" class="underline text-blue-300">Back to Home</a>
+</Container>

--- a/src/routes/users/[id]/+page.server.ts
+++ b/src/routes/users/[id]/+page.server.ts
@@ -1,5 +1,6 @@
 import prisma from '$lib/prisma';
 import type { PageServerLoad, Actions } from './$types';
+import { error } from '@sveltejs/kit';
 
 export const load: PageServerLoad = async ({ params: { id } }) => {
 	const user = await prisma.user.findUnique({
@@ -7,8 +8,7 @@ export const load: PageServerLoad = async ({ params: { id } }) => {
 		include: { initiatorIn: true, recipientIn: true }
 	});
 	if (!user) {
-		//TODO: Thisis not the correct way to handle any error here
-		throw new Error('User not found');
+		throw error(404, 'User not found');
 	}
 
 	const otherUsers = await prisma.user.findMany({

--- a/src/routes/users/[id]/page.server.spec.ts
+++ b/src/routes/users/[id]/page.server.spec.ts
@@ -1,0 +1,24 @@
+import { describe, it, expect, vi } from 'vitest';
+import type { Mock } from 'vitest';
+import type { PageServerLoadEvent } from './$types';
+
+vi.mock('$lib/prisma', () => ({
+	default: {
+		user: {
+			findUnique: vi.fn(),
+			findMany: vi.fn()
+		}
+	}
+}));
+
+import { load } from './+page.server';
+import prisma from '$lib/prisma';
+
+describe('user page loader', () => {
+	it('throws 404 when user is missing', async () => {
+		(prisma.user.findUnique as unknown as Mock).mockResolvedValue(null);
+
+		const event = { params: { id: '1' } } as unknown as PageServerLoadEvent;
+		await expect(load(event)).rejects.toMatchObject({ status: 404 });
+	});
+});


### PR DESCRIPTION
## Summary
- revert accidental package-lock.json changes
- add a vitest spec for the users/[id] loader

## Testing
- `npx vitest run`
- `npm run check`
