### PR TITLE
Use global jsdom for component tests

### DIFF
--- a/src/lib/components/__tests__/UserCard.spec.ts
+++ b/src/lib/components/__tests__/UserCard.spec.ts
@@ -1,6 +1,5 @@
 import { beforeAll, describe, it, expect } from 'vitest';
 import { compile } from 'svelte/compiler';
-import { JSDOM } from 'jsdom';
 import fs from 'fs';
 import path from 'path';
 
@@ -18,8 +17,8 @@ beforeAll(async () => {
 function render(props: Record<string, unknown>) {
 	const payload = { out: '' };
 	renderComponent(payload, props);
-	const dom = new JSDOM(payload.out);
-	return dom.window.document;
+	const doc = new DOMParser().parseFromString(payload.out, 'text/html');
+	return doc;
 }
 
 describe('UserCard', () => {

--- a/src/lib/components/users/__tests__/TransactionTable.spec.ts
+++ b/src/lib/components/users/__tests__/TransactionTable.spec.ts
@@ -1,6 +1,5 @@
 import { beforeAll, describe, expect, it } from 'vitest';
 import { compile } from 'svelte/compiler';
-import { JSDOM } from 'jsdom';
 import fs from 'fs';
 import path from 'path';
 
@@ -54,8 +53,8 @@ describe('TransactionTable', () => {
 		const payload = { out: '', head: { out: '', title: '' } };
 		renderComponent(payload, { transactions, title: 'Recent transactions' });
 
-		const dom = new JSDOM(payload.out);
-		const rows = dom.window.document.querySelectorAll('li');
+		const doc = new DOMParser().parseFromString(payload.out, 'text/html');
+		const rows = doc.querySelectorAll('li');
 		expect(rows.length).toBe(transactions.length);
 
 		rows.forEach((row, index) => {


### PR DESCRIPTION
## Summary
- rely on Vitest's global jsdom environment instead of importing `JSDOM`
- parse SSR output with `DOMParser` in tests

## Testing
- `npx vitest run`