### PR TITLE
Switch recipient selection to user IDs

### DIFF
--- a/src/routes/users/[id]/+page.server.ts
+++ b/src/routes/users/[id]/+page.server.ts
@@ -66,15 +66,14 @@ export const actions: Actions = {
 		const formData = await request.formData();
 		const initiatorId = Number(params.id);
 		const amount = formData.get('amount');
-		const recipientName = formData.get('recipient');
+		const recipientId = formData.get('recipient');
 		const reason = formData.get('reason');
 
 		const initiator = await prisma.user.findUniqueOrThrow({
 			where: { id: Number(initiatorId) }
 		});
-		// TODO: Figure out how to use ids in the frontend
-		const recipient = await prisma.user.findFirstOrThrow({
-			where: { name: '' + recipientName }
+		const recipient = await prisma.user.findUniqueOrThrow({
+			where: { id: Number(recipientId) }
 		});
 
 		await prisma.transaction.create({

--- a/src/routes/users/[id]/+page.svelte
+++ b/src/routes/users/[id]/+page.svelte
@@ -88,12 +88,12 @@
 		</label>
 		<label>
 			Recipient
-			<input list="recipients" name="recipient" id="recipient" />
-			<datalist id="recipients">
+			<select name="recipient" id="recipient">
+				<option value="" disabled selected hidden>Select recipient</option>
 				{#each data.otherUsers as user (user.id)}
-					<option value={user.name}> </option>
+					<option value={user.id}>{user.name}</option>
 				{/each}
-			</datalist>
+			</select>
 		</label>
 
 		{#if transferError}

--- a/src/routes/users/[id]/__tests__/actions.spec.ts
+++ b/src/routes/users/[id]/__tests__/actions.spec.ts
@@ -1,9 +1,9 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { Mock } from 'vitest';
 
 interface PrismaMock {
 	user: {
 		findUniqueOrThrow: ReturnType<typeof vi.fn>;
-		findFirstOrThrow: ReturnType<typeof vi.fn>;
 		update: ReturnType<typeof vi.fn>;
 	};
 	transaction: {
@@ -18,7 +18,6 @@ vi.mock('$lib/prisma', () => {
 	prismaMock = {
 		user: {
 			findUniqueOrThrow: vi.fn(async () => ({ id: 1 })),
-			findFirstOrThrow: vi.fn(async () => ({ id: 2 })),
 			update: vi.fn(async () => ({}))
 		},
 		transaction: {
@@ -72,9 +71,11 @@ describe('user actions', () => {
 	});
 
 	it('creates transfer transaction with recipient and reason', async () => {
+		(prismaMock.user.findUniqueOrThrow as Mock).mockResolvedValueOnce({ id: 1 });
+		(prismaMock.user.findUniqueOrThrow as Mock).mockResolvedValueOnce({ id: 2 });
 		const fd = new FormData();
 		fd.set('amount', '25');
-		fd.set('recipient', 'Bob');
+		fd.set('recipient', '2');
 		fd.set('reason', 'Lunch');
 		const request = { formData: vi.fn(async () => fd) } as unknown as Request;
 


### PR DESCRIPTION
## Summary
- replace datalist recipient input with select dropdown in `+page.svelte`
- fetch recipient by id in the transfer action
- update tests for id-based transfer

## Testing
- `npm test`
